### PR TITLE
Add ability for radio to send battery voltages

### DIFF
--- a/serialize.c
+++ b/serialize.c
@@ -137,7 +137,7 @@ bool deserialize_state(system_state *state, const char *str)
     // Bits 5-2 represent bits 3-0 of the bus battery voltage
     state->bus_battery_voltage_mv |= (raw & 0x3c) >> 2;
     // Bits 1-0 represent bits 13-12 of the vent battery voltage
-    state->vent_battery_voltage_mv = (uint16_t) (raw &0x3) << 12;
+    state->vent_battery_voltage_mv = (uint16_t) (raw & 0x3) << 12;
 
     raw = base64_to_binary(str[6]);
     // Bits 5-0 represent bits 11-6 of the vent battery voltage

--- a/serialize.c
+++ b/serialize.c
@@ -55,7 +55,7 @@ bool serialize_state(const system_state *state, char *str)
     raw |= ((state->tank_pressure >> 6) & 0xf);
     str[1] = binary_to_base64(raw);
 
-    //use all the bits of this next one to hold bits 5-0 of tank pressure
+    // Use all the bits of this next one to hold bits 5-0 of tank pressure
     raw = (state->tank_pressure & 0x3f);
     str[2] = binary_to_base64(raw);
 
@@ -66,9 +66,33 @@ bool serialize_state(const system_state *state, char *str)
     // Bit 4 represents whether errors have been detected
     if (state->any_errors_detected)
         raw |= 0b00010000;
+    // Bits 3-0 are the top bits 13-10 of the bus battery voltage
+    raw |= (state->bus_battery_voltage_mv >> 10) & 0xf;
     str[3] = binary_to_base64(raw);
 
-    str[4] = '\0';
+    raw = 0;
+    // Bits 5-0 hold bits 9-4 of the bus battery voltage
+    raw = (state->bus_battery_voltage_mv >> 4) & 0x3f ;
+    str[4] = binary_to_base64(raw);
+
+    raw = 0;
+    // Bits 5-2 hold bits 3-0 of the bus battery voltage
+    raw = (state->bus_battery_voltage_mv & 0xf) << 2;
+    // Bits 1-0 hold bits 13-12 of the vent battery voltage
+    raw |= (state->vent_battery_voltage_mv >> 12) & 0x3;
+    str[5] = binary_to_base64(raw);
+
+    raw = 0;
+    // Bits 5-0 hold bits 11-6 of the vent battery voltage
+    raw = (state->vent_battery_voltage_mv >> 6) & 0x3f;
+    str[6] = binary_to_base64(raw);
+
+    raw = 0;
+    // Bits 5-0 hold bits 5-0 of the vent battery voltage
+    raw = (state->vent_battery_voltage_mv & 0x3f);
+    str[7] = binary_to_base64(raw);
+
+    str[8] = '\0';
 
     return true;
 }
@@ -84,7 +108,7 @@ bool deserialize_state(system_state *state, const char *str)
 
     // Bits 5-2 represent the number of boards connected
     state->num_boards_connected = (raw & 0b00111100) >> 2;
-    // Bits 1-0 respresent injector valve state
+    // Bits 1-0 represent injector valve state
     state->injector_valve_state = raw & 0x3;
 
     raw = base64_to_binary(str[1]);
@@ -102,6 +126,26 @@ bool deserialize_state(system_state *state, const char *str)
     state->bus_is_powered = raw & 0x20;
     // Bit 4 represents whether any errors are active
     state->any_errors_detected = raw & 0x10;
+    // Bits 3-0 represent the top 13-10 bits of the bus battery voltage
+    state->bus_battery_voltage_mv = (uint16_t) (raw & 0xf) << 10;
+
+    raw = base64_to_binary(str[4]);
+    // Bits 5-0 represent bits 9-4 of the bus battery voltage
+    state->bus_battery_voltage_mv |= (raw & 0x3f) << 4;
+
+    raw = base64_to_binary(str[5]);
+    // Bits 5-2 represent bits 3-0 of the bus battery voltage
+    state->bus_battery_voltage_mv |= (raw & 0x3c) >> 2;
+    // Bits 1-0 represent bits 13-12 of the vent battery voltage
+    state->vent_battery_voltage_mv = (uint16_t) (raw &0x3) << 12;
+
+    raw = base64_to_binary(str[6]);
+    // Bits 5-0 represent bits 11-6 of the vent battery voltage
+    state->vent_battery_voltage_mv |= (raw & 0x3f) << 6;
+
+    raw = base64_to_binary(str[7]);
+    // Bits 5-0 represent bits 5-0 of the vent battery voltage
+    state->vent_battery_voltage_mv |= raw & 0x3f;
 
     return true;
 }

--- a/serialize.h
+++ b/serialize.h
@@ -19,7 +19,7 @@
  * with a couple of additional bytes for STATE_COMMAND header and for a
  * CRC or hamming code
  */
-#define STATE_COMMAND_LEN SERIALIZED_OUTPUT_LEN + 2
+#define STATE_COMMAND_LEN (SERIALIZED_OUTPUT_LEN + 2)
 /*
  * This character indicates the beginning of a state command.
  */

--- a/serialize.h
+++ b/serialize.h
@@ -12,14 +12,14 @@
  * a serialized system state should have SERIALIZED_OUTPUT_LEN - 1 ascii
  * characters in it
  */
-#define SERIALIZED_OUTPUT_LEN 5
+#define SERIALIZED_OUTPUT_LEN 9
 /*
  * Length of a state command. A state command is a block of characters
  * that can be sent over the radio. It's mostly the serialized state output
  * with a couple of additional bytes for STATE_COMMAND header and for a
  * CRC or hamming code
  */
-#define STATE_COMMAND_LEN 7
+#define STATE_COMMAND_LEN SERIALIZED_OUTPUT_LEN + 2
 /*
  * This character indicates the beginning of a state command.
  */
@@ -44,6 +44,8 @@ typedef struct {
     enum VALVE_STATE vent_valve_state;
     bool bus_is_powered;
     bool any_errors_detected;
+    uint16_t bus_battery_voltage_mv;
+    uint16_t vent_battery_voltage_mv;
 } system_state;
 
 /*

--- a/sotscon.c
+++ b/sotscon.c
@@ -184,11 +184,11 @@ void handle_incoming_can_message(const can_msg_t *msg)
                 }
                 if (msg->data[2] == SENSOR_VENT_BATT) {
                     // we have a vent battery voltage, update the battery voltage
-                    vent_battery_voltage_mv = (uint16_t) msg->data[3] << 8 | msg->data[4];
+                    vent_battery_voltage_mv = ((uint16_t) msg->data[3] << 8) | msg->data[4];
                 }
                 if (msg->data[2] == SENSOR_INJ_BATT) {
                     // we have a inj battery voltage, update the battery voltage
-                    inj_battery_voltage_mv = (uint16_t) msg->data[3] << 8 | msg->data[4];
+                    inj_battery_voltage_mv = ((uint16_t) msg->data[3] << 8) | msg->data[4];
                 }
                 boards[sender_unique_id].valid = true;
                 boards[sender_unique_id].time_last_message_received_ms = millis();

--- a/sotscon.c
+++ b/sotscon.c
@@ -9,10 +9,10 @@
 
 /*
  * We key boards by their unique id. In theory there could be up to 32 of
- * these, but at present there are only 12 defined IDs, so we can have just
+ * these, but at present there are only 14 defined IDs, so we can have just
  * those.
  */
-#define MAX_BOARD_UNIQUE_ID 0x0C
+#define MAX_BOARD_UNIQUE_ID 0x0E
 
 /*
  * We keep track of how many consecutive E_NOMINAL general status messages
@@ -68,9 +68,8 @@ static bool errors_active = false;
 static uint16_t last_tank_pressure = 0;
 
 /*
- * Keep track of the battery voltage for both the vent and injector valves
- * (although injector valve battery is currently not being used). These
- * voltages are in millivolts.
+ * Keep track of the battery voltage for both the vent and injector valves.
+ * These voltages are in millivolts.
  */
 static uint16_t vent_battery_voltage_mv = 0;
 static uint16_t inj_battery_voltage_mv = 0;
@@ -263,6 +262,16 @@ uint16_t current_tank_pressure(void)
     } else {
         return last_tank_pressure;
     }
+}
+
+uint16_t current_vent_batt_mv(void)
+{
+    return vent_battery_voltage_mv;
+}
+
+uint16_t current_inj_batt_mv(void)
+{
+    return inj_battery_voltage_mv;
 }
 
 /* Private function definitions */

--- a/sotscon.c
+++ b/sotscon.c
@@ -67,6 +67,14 @@ static bool errors_active = false;
  */
 static uint16_t last_tank_pressure = 0;
 
+/*
+ * Keep track of the battery voltage for both the vent and injector valves
+ * (although injector valve battery is currently not being used). These
+ * voltages are in millivolts.
+ */
+static uint16_t vent_battery_voltage_mv = 0;
+static uint16_t inj_battery_voltage_mv = 0;
+
 /* Private function declarations */
 static void update_all_timeouts(void);
 static void update_errors_active(void);
@@ -173,6 +181,14 @@ void handle_incoming_can_message(const can_msg_t *msg)
                 if (msg->data[2] == SENSOR_PRESSURE_OX) {
                     // we have a pressure, update the pressure
                     last_tank_pressure = ((uint16_t) msg->data[3] << 8) | msg->data[4];
+                }
+                if (msg->data[2] == SENSOR_VENT_BATT) {
+                    // we have a vent battery voltage, update the battery voltage
+                    vent_battery_voltage_mv = (uint16_t) msg->data[3] << 8 | msg->data[4];
+                }
+                if (msg->data[2] == SENSOR_INJ_BATT) {
+                    // we have a inj battery voltage, update the battery voltage
+                    inj_battery_voltage_mv = (uint16_t) msg->data[3] << 8 | msg->data[4];
                 }
                 boards[sender_unique_id].valid = true;
                 boards[sender_unique_id].time_last_message_received_ms = millis();

--- a/sotscon.h
+++ b/sotscon.h
@@ -84,4 +84,12 @@ bool any_errors_active(void);
  */
 uint16_t current_tank_pressure(void);
 
+/*
+ * These two functions return the last received battery voltages from vent and
+ * injector. These functions do not clamp their return values, so can return
+ * up to 65535.
+ */
+uint16_t current_vent_batt_mv(void);
+uint16_t current_inj_batt_mv(void);
+
 #endif


### PR DESCRIPTION
This gives the ability for radio to send battery voltages to RLCS
from both the bus and vent sections of the rocket so they can be
monitored during tests and flight.

This has not been tested and should be before approved.